### PR TITLE
Support for STL files created by SolidWorks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Turn STL files into voxels, images, and videos
 * Convert stl files into a voxel representation
 * Output to (a series of) .pngs, .xyz, .svx
 * Command line interface
+
 ### How to run
 ```
 git clone https://github.com/rcpedersen/stl-to-voxel.git

--- a/stl_reader.py
+++ b/stl_reader.py
@@ -59,8 +59,12 @@ def AsciiSTL(fname):
             elif init:
                 words = line.strip().split(' ')
                 assert words[0] == 'vertex'
-                verticies.append((float(words[3]), float(words[5]), float(words[7])))
-                #verticies.append((float(words[1]), float(words[2]), float(words[3])))
+                if(words[1]):
+                     verticies.append((float(words[1]), float(words[2]), float(words[3])))
+                else:
+                     #for STL files in which 'words' looks like(from Solidworks):
+                     #['vertex', '', '', '1', '', '2', '', '3']
+                     verticies.append((float(words[3]), float(words[5]), float(words[7])))
 
     return triangles
 

--- a/stl_reader.py
+++ b/stl_reader.py
@@ -59,7 +59,8 @@ def AsciiSTL(fname):
             elif init:
                 words = line.strip().split(' ')
                 assert words[0] == 'vertex'
-                verticies.append((float(words[1]), float(words[2]), float(words[3])))
+                verticies.append((float(words[3]), float(words[5]), float(words[7])))
+                #verticies.append((float(words[1]), float(words[2]), float(words[3])))
 
     return triangles
 

--- a/stl_reader.py
+++ b/stl_reader.py
@@ -58,13 +58,10 @@ def AsciiSTL(fname):
                 continue
             elif init:
                 words = line.strip().split(' ')
+                words=list(filter(None,words))
                 assert words[0] == 'vertex'
-                if(words[1]):
-                     verticies.append((float(words[1]), float(words[2]), float(words[3])))
-                else:
-                     #for STL files in which 'words' looks like(from Solidworks):
-                     #['vertex', '', '', '1', '', '2', '', '3']
-                     verticies.append((float(words[3]), float(words[5]), float(words[7])))
+                verticies.append((float(words[1]), float(words[2]), float(words[3])))
+
 
     return triangles
 

--- a/stltovoxel.py
+++ b/stltovoxel.py
@@ -45,12 +45,22 @@ def exportPngs(voxels, bounding_box, outputFilePath):
         path = (outputFilePattern + "%0" + size + "d.png")%height
         img.save(path)
 
+#def exportXyz(voxels, bounding_box, outputFilePath):
+    #output = open(outputFilePath, 'w')
+    #for z in bounding_box[2]:
+        #for x in bounding_box[0]:
+            #for y in bounding_box[1]:
+                #if vol[z][x][y]:
+                    #output.write('%s %s %s\n'%(x,y,z))
+    #output.close()
+
+#fix from github user artBoffin   
 def exportXyz(voxels, bounding_box, outputFilePath):
     output = open(outputFilePath, 'w')
-    for z in bounding_box[2]:
-        for x in bounding_box[0]:
-            for y in bounding_box[1]:
-                if vol[z][x][y]:
+    for z in range(bounding_box[2]):
+        for x in range(bounding_box[0]):
+            for y in range(bounding_box[1]):
+                if voxels[z][x][y]:
                     output.write('%s %s %s\n'%(x,y,z))
     output.close()
 

--- a/stltovoxel.py
+++ b/stltovoxel.py
@@ -47,7 +47,6 @@ def exportPngs(voxels, bounding_box, outputFilePath):
 
 def exportXyz(voxels, bounding_box, outputFilePath):
     output = open(outputFilePath, 'w')
-    print(bounding_box[2])
     for z in bounding_box[2]:
         for x in bounding_box[0]:
             for y in bounding_box[1]:

--- a/stltovoxel.py
+++ b/stltovoxel.py
@@ -47,6 +47,7 @@ def exportPngs(voxels, bounding_box, outputFilePath):
 
 def exportXyz(voxels, bounding_box, outputFilePath):
     output = open(outputFilePath, 'w')
+    print(bounding_box[2])
     for z in bounding_box[2]:
         for x in bounding_box[0]:
             for y in bounding_box[1]:
@@ -93,7 +94,11 @@ def file_choices(choices,fname):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Convert STL files to voxels')
-    parser.add_argument('input', nargs='?', type=lambda s:file_choices(('.stl'),s))
-    parser.add_argument('output', nargs='?', type=lambda s:file_choices(('.png', '.xyz', '.svx'),s))
+    parser.add_argument('input', nargs='?', type=lambda s:file_choices(('.stl'),s),help='The input STL file')
+    parser.add_argument('output', nargs='?', type=lambda s:file_choices(('.png', '.xyz', '.svx'),s), help='path to output files. The export data type is chosen by file extension. Possible are .png, .xyz and .svx')
+    parser.add_argument('resolution', nargs='?', type=int, help='number of voxels in both directions')
     args = parser.parse_args()
-    doExport(args.input, args.output, 100)
+    if(args.resolution):	
+        doExport(args.input, args.output, args.resolution)
+    else:
+        doExport(args.input, args.output, 100)


### PR DESCRIPTION
Some STL files, e.g. those from SolidWorks, don't work, because they have the vertex coordinates at words[3], words[5] and words[7], instead of words[1], words[2] and words[3].
A simple fix is to check if words[1] is empty.