### PR TITLE
fixed export XYZ - for loop range and wrong parameter spelling

### DIFF
--- a/stltovoxel.py
+++ b/stltovoxel.py
@@ -47,10 +47,10 @@ def exportPngs(voxels, bounding_box, outputFilePath):
 
 def exportXyz(voxels, bounding_box, outputFilePath):
     output = open(outputFilePath, 'w')
-    for z in bounding_box[2]:
-        for x in bounding_box[0]:
-            for y in bounding_box[1]:
-                if vol[z][x][y]:
+    for z in range(bounding_box[2]):
+        for x in range(bounding_box[0]):
+            for y in range(bounding_box[1]):
+                if voxels[z][x][y]:
                     output.write('%s %s %s\n'%(x,y,z))
     output.close()
 


### PR DESCRIPTION
for loops have to iterate over the range of the bounding_box not over the integer value itself
renamed undefined variable vol to parameter voxels