### PR TITLE
resolve Issues/31 (support pip install method)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ Turn STL files into voxels, images, and videos
 
 ### How to run
 ```
-git clone https://github.com/cpederkoff/stl-to-voxel.git
+$ git clone https://github.com/cpederkoff/stl-to-voxel.git
 $ cd stl-to-voxel
-
 $ python3 stltovoxel.py data/Stanford_Bunny.stl data/Stanford_Bunny.png
 ```
+
+```
+$ pip install git+https://github.com/cpederkoff/stl-to-voxel.git
+>>> import stltovoxel
+>>> stltovoxel.doExport('data/Stanford_Bunny.stl', 'data/Stanford_Bunny.png')
+```
+
 <!--- https://commons.wikimedia.org/wiki/File:Stanford_Bunny.stl --->
 
 The resolution is optional and defaults to 100.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.append(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup
+
+with open("README.md", "r") as f:
+    LONG_DESCRIPTION = f.read()
+
+setup(
+    name='stl-to-voxel',
+    version='0.9.1',
+    description='Turn STL files into voxels, images, and videos',
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
+    license='MIT',
+    keywords='stl python voxel',
+    author='Christian Pederkoff',
+    url='https://github.com/cpederkoff/stl-to-voxel',
+    download_url='https://github.com/cpederkoff/stl-to-voxel/releases',
+    install_requires=['numpy', 'Pillow', 'matplotlib'],
+    py_modules=['perimeter', 'slice', 'stl_reader', 'stltovoxel', 'util'],
+    python_requires='>=3',
+    zip_safe=False,
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+)

--- a/stltovoxel.py
+++ b/stltovoxel.py
@@ -11,14 +11,14 @@ import slice
 import stl_reader
 
 
-def doExport(inputFilePath, outputFilePath, resolution, pad, bounding_box=None):
+def doExport(inputFilePath, outputFilePath, resolution=100, pad=1, parallel=False):
     org_mesh = stl_reader.read_stl_verticies(inputFilePath)
     vol_mesh, scale, shift, bounding_box = slice.scaleAndShiftMesh(org_mesh, resolution)
     if scale == 0:
         print('Too small resolution: %d' % resolution)
         return
 
-    vol, bounding_box = slice.meshToPlane(vol_mesh, bounding_box, pad)
+    vol, bounding_box = slice.meshToPlane(vol_mesh, bounding_box, pad, parallel)
 
     outputFilePattern, outputFileExtension = os.path.splitext(outputFilePath)
     if outputFileExtension == '.png':
@@ -90,6 +90,16 @@ def file_choices(choices, fname):
 
 
 if __name__ == '__main__':
+    def str2bool(v):
+        if isinstance(v, bool):
+            return v
+        if v.lower() in ('yes', 'true', 't', 'y', '1'):
+            return True
+        elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+            return False
+        else:
+            raise argparse.ArgumentTypeError('Boolean value expected.')
+
     parser = argparse.ArgumentParser(description='Convert STL files to voxels')
     parser.add_argument('input', nargs='?', type=lambda s: file_choices(('.stl', ), s), help='The input STL file')
     parser.add_argument(
@@ -98,6 +108,7 @@ if __name__ == '__main__':
         help='path to output files. The export data type is chosen by file extension. Possible are .png, .xyz and .svx')
     parser.add_argument('resolution', nargs='?', type=int, default=100, help='number of voxels in both directions')
     parser.add_argument('pad', nargs='?', type=int, default=1, help='number of padding pixels')
+    parser.add_argument('parallel', nargs='?', type=str2bool, default=True, help='parallel processing')
 
     args = parser.parse_args()
-    doExport(args.input, args.output, args.resolution, args.pad)
+    doExport(args.input, args.output, args.resolution, args.pad, args.parallel)


### PR DESCRIPTION
I implemented stl-to-voxel so that it can be used with `pip install` as well as `git clone`.
I have informed users in advance in https://github.com/cpederkoff/stl-to-voxel/issues/31.

```
$ pip install git+https://github.com/cpederkoff/stl-to-voxel.git
>>> import stltovoxel
>>> stltovoxel.doExport('data/Stanford_Bunny.stl', 'data/Stanford_Bunny.png')
```
It is also explained in the README.