### PR TITLE
add feature - different resolution for each axis

### DIFF
--- a/stltovoxel/main.py
+++ b/stltovoxel/main.py
@@ -11,12 +11,12 @@ import numpy as np
 from . import slice
 
 
-def convert_mesh(mesh, resolution=100, parallel=True):
-    return convert_meshes([mesh], resolution, parallel)
+def convert_mesh(mesh,resolution_x=100,resolution_y=100,resolution_z=0, parallel=True):
+    return convert_meshes([mesh], resolution_x=resolution_x,resolution_y=resolution_y, resolution_z=resolution_z, parallel=parallel)
 
 
-def convert_meshes(meshes, resolution=100, parallel=True):
-    scale, shift, shape = slice.calculate_scale_shift(meshes, resolution)
+def convert_meshes(meshes ,resolution_x, resolution_y, resolution_z, parallel=True):
+    scale, shift, shape = slice.calculate_scale_shift(meshes,resolution_x, resolution_y, resolution_z)
     vol = np.zeros(shape[::-1], dtype=np.int8)
 
     for mesh_ind, org_mesh in enumerate(meshes):
@@ -26,18 +26,18 @@ def convert_meshes(meshes, resolution=100, parallel=True):
     return vol, scale, shift
 
 
-def convert_file(input_file_path, output_file_path, resolution=100, pad=1, parallel=False):
-    convert_files([input_file_path], output_file_path, resolution=resolution, pad=pad, parallel=parallel)
+def convert_file(input_file_path, output_file_path, resolution_x=100, resolution_y=100, resolution_z=0, pad=1, parallel=False):
+    convert_files([input_file_path], output_file_path, resolution_x=resolution_x, resolution_y=resolution_y, resolution_z=resolution_z , pad=pad, parallel=parallel)
 
 
-def convert_files(input_file_paths, output_file_path, colors=[(255, 255, 255)], resolution=100, pad=1, parallel=False):
+def convert_files(input_file_paths, output_file_path, resolution_x , resolution_y, resolution_z,colors=[(255, 255, 255)], pad=1, parallel=False):
     meshes = []
     for input_file_path in input_file_paths:
         mesh_obj = mesh.Mesh.from_file(input_file_path)
         org_mesh = np.hstack((mesh_obj.v0[:, np.newaxis], mesh_obj.v1[:, np.newaxis], mesh_obj.v2[:, np.newaxis]))
         meshes.append(org_mesh)
 
-    vol, scale, shift = convert_meshes(meshes, resolution, parallel)
+    vol, scale, shift = convert_meshes(meshes,resolution_x,resolution_y,resolution_z,parallel)
     output_file_pattern, output_file_extension = os.path.splitext(output_file_path)
     if output_file_extension == '.png':
         vol = np.pad(vol, pad)
@@ -145,7 +145,9 @@ def main():
         'output',
         type=lambda s: file_choices(parser, ('.png', '.npy', '.svx', '.xyz'), s),
         help='Path to output files. The export data type is chosen by file extension. Possible are .png, .xyz and .svx')
-    parser.add_argument('--resolution', type=int, default=100, help='Number of voxels in the largest dimension')
+    parser.add_argument('--resolution_x', type=int, default=100, help='Number of voxels in x direction')
+    parser.add_argument('--resolution_y', type=int, default=100, help='Number of voxels in y direction')
+    parser.add_argument('--resolution_z', type=int, default=0, help='Number of voxels in z direction, this is auto calculated if not provided by the user')
     parser.add_argument('--pad', type=int, default=1, help='Number of padding pixels. Only used during .png output.')
     parser.add_argument('--no-parallel', dest='parallel', action='store_false', help='Disable parallel processing')
     parser.add_argument('--colors', type=str, default="#FFFFFF", help='Output png colors. Ex red,#FF0000')

--- a/stltovoxel/slice.py
+++ b/stltovoxel/slice.py
@@ -1,6 +1,6 @@
+import math
 import numpy as np
 import multiprocessing as mp
-
 from . import perimeter
 
 
@@ -113,7 +113,7 @@ def calculate_scale_shift(meshes, resolution_x, resolution_y, resolution_z):
         mesh_min = np.minimum(mesh_min, mesh.min(axis=(0, 1)))
         mesh_max = np.maximum(mesh_max, mesh.max(axis=(0, 1)))
 
-    bounding_box = mesh_max - mesh_min
+    amplitude = mesh_max - mesh_min
     # Floating point errors can creep in here. Ex: 25 * 1.16 = 28.999999999999996
     # Need to be careful about when numbers are divided.
 


### PR DESCRIPTION
This PR provides a feature to have separate resolution for each axis. Therefore, the user can now work with specific voxel sizes if he wants to.
If the user does not provide specific resolutions then the default resolution is set to 100 along x and y axis and the z resolution is auto calculated. Otherwise, the resolution provided by the user will be used.