### PR TITLE
Split main.py file

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pep8-naming pytest
+        python -m pip install flake8 pep8-naming nose
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |
@@ -37,6 +37,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with nose
       run: |
-        pytest
+        nosetests test/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ stltovoxel.convert_file('input.stl', 'output.png')
 ```bash
 git clone https://github.com/cpederkoff/stl-to-voxel.git
 cd stl-to-voxel
-python3 -m stltovoxel.main input.stl output.png
+python3 -m stltovoxel input.stl output.png
 ```
 
 <!--- https://commons.wikimedia.org/wiki/File:Stanford_Bunny.stl --->
 
 The resolution is optional and defaults to 100.
 
-### Example: 
+### Example:
 ![alt text](https://github.com/cpederkoff/stl-to-voxel/raw/master/data/stanford_bunny.png "STL version of the stanford bunny")
 ![alt text](https://github.com/cpederkoff/stl-to-voxel/raw/master/data/stanford_bunny.gif "voxel version of the stanford bunny")
 ### Multi-color Example:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     zip_safe=False,
     entry_points={
         'console_scripts': [
-            'stltovoxel = stltovoxel.main:main',
+            'stltovoxel = stltovoxel.__main__:main',
         ],
     },
     classifiers=[
@@ -28,5 +28,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/stltovoxel/__init__.py
+++ b/stltovoxel/__init__.py
@@ -1,4 +1,4 @@
-from .main import convert_file, convert_files, convert_mesh, convert_meshes
+from .convert import convert_file, convert_files, convert_mesh, convert_meshes
 
 __all__ = [
     'convert_file',

--- a/stltovoxel/__main__.py
+++ b/stltovoxel/__main__.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+from PIL import ImageColor
+
+from .convert import convert_files
+
+
+def file_choices(parser, choices, fname):
+    filename, ext = os.path.splitext(fname)
+    if ext == '' or ext.lower() not in choices:
+        if len(choices) == 1:
+            parser.error('%s doesn\'t end with %s' % (fname, choices))
+        else:
+            parser.error('%s doesn\'t end with one of %s' % (fname, choices))
+    return fname
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert STL files to voxels')
+    parser.add_argument('input', nargs='+', type=lambda s: file_choices(parser, ('.stl'), s), help='Input STL file')
+    parser.add_argument(
+        'output',
+        type=lambda s: file_choices(parser, ('.png', '.npy', '.svx', '.xyz'), s),
+        help='Path to output files. The export data type is chosen by file extension. Possible are .png, .xyz and .svx')
+    parser.add_argument('--pad', type=int, default=1, help='Number of padding pixels. Only used during .png output.')
+    parser.add_argument('--no-parallel', dest='parallel', action='store_false', help='Disable parallel processing')
+    parser.add_argument('--colors', type=str, default="#FFFFFF", help='Output png colors. Ex red,#FF0000')
+    # Only one resolution argument may be set
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--resolution', type=int, default=100, help='Number of voxels in z direction')
+    group.add_argument('--resolution-xyz', type=int, default=[100, 100, 100], nargs=3, dest='resolution',
+                       help='Number of voxels in x, y, and z direction.')
+
+    parser.set_defaults(parallel=True)
+
+    args = parser.parse_args()
+    colors = args.colors.split(",")
+    if os.path.splitext(args.output)[1] == '.png' and len(colors) < len(args.input):
+        raise argparse.ArgumentTypeError('Must specify enough colors')
+
+    color_tuples = [ImageColor.getcolor(color, "RGB") for color in colors]
+    convert_files(args.input, args.output, color_tuples, args.resolution, args.pad, args.parallel)
+
+
+if __name__ == '__main__':
+    main()

--- a/stltovoxel/convert.py
+++ b/stltovoxel/convert.py
@@ -1,8 +1,7 @@
-import argparse
 import io
 import glob
 import os
-from PIL import Image, ImageColor
+from PIL import Image
 from stl import mesh
 import xml.etree.cElementTree as ETree
 import zipfile
@@ -126,44 +125,3 @@ def export_svx(voxels, output_file_path, scale, shift):
             img.save(output, format="PNG")
             zip_file.writestr(("density/slice%0" + size + "d.png") % height, output.getvalue())
         zip_file.writestr("manifest.xml", manifest)
-
-
-def file_choices(parser, choices, fname):
-    filename, ext = os.path.splitext(fname)
-    if ext == '' or ext.lower() not in choices:
-        if len(choices) == 1:
-            parser.error('%s doesn\'t end with %s' % (fname, choices))
-        else:
-            parser.error('%s doesn\'t end with one of %s' % (fname, choices))
-    return fname
-
-
-def main():
-    parser = argparse.ArgumentParser(description='Convert STL files to voxels')
-    parser.add_argument('input', nargs='+', type=lambda s: file_choices(parser, ('.stl'), s), help='Input STL file')
-    parser.add_argument(
-        'output',
-        type=lambda s: file_choices(parser, ('.png', '.npy', '.svx', '.xyz'), s),
-        help='Path to output files. The export data type is chosen by file extension. Possible are .png, .xyz and .svx')
-    parser.add_argument('--pad', type=int, default=1, help='Number of padding pixels. Only used during .png output.')
-    parser.add_argument('--no-parallel', dest='parallel', action='store_false', help='Disable parallel processing')
-    parser.add_argument('--colors', type=str, default="#FFFFFF", help='Output png colors. Ex red,#FF0000')
-    # Only one resolution argument may be set
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('--resolution', type=int, default=100, help='Number of voxels in z direction')
-    group.add_argument('--resolution-xyz', type=int, default=[100, 100, 100], nargs=3, dest='resolution',
-                       help='Number of voxels in x, y, and z direction.')
-
-    parser.set_defaults(parallel=True)
-
-    args = parser.parse_args()
-    colors = args.colors.split(",")
-    if os.path.splitext(args.output)[1] == '.png' and len(colors) < len(args.input):
-        raise argparse.ArgumentTypeError('Must specify enough colors')
-
-    color_tuples = [ImageColor.getcolor(color, "RGB") for color in colors]
-    convert_files(args.input, args.output, color_tuples, args.resolution, args.pad, args.parallel)
-
-
-if __name__ == '__main__':
-    main()

--- a/test/context.py
+++ b/test/context.py
@@ -1,5 +1,0 @@
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import stltovoxel  # noqa: F401,E402

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -3,7 +3,6 @@ import tempfile
 import unittest
 import numpy as np
 
-from .context import stltovoxel  # noqa: F401
 from stltovoxel.convert import convert_file, convert_mesh
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -4,61 +4,61 @@ import unittest
 import numpy as np
 
 from .context import stltovoxel  # noqa: F401
-from stltovoxel import main
+from stltovoxel.convert import convert_file, convert_mesh
 
 
 class TestMain(unittest.TestCase):
     def test_sample(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # https://commons.wikimedia.org/wiki/File:Stanford_Bunny.stl
-            main.convert_file('data/Stanford_Bunny.stl', os.path.join(tmp_dir, 'stanford_bunny.png'), 100, 1)
+            convert_file('data/Stanford_Bunny.stl', os.path.join(tmp_dir, 'stanford_bunny.png'), 100, 1)
             # https://ozeki.hu/p_1116-sample-stl-files-you-can-use-for-testing.html
-            main.convert_file('data/Cube_3d_printing_sample.stl', os.path.join(tmp_dir, 'Cube_3d_printing_sample.png'), 100, 1)
-            main.convert_file('data/Menger_sponge_sample.stl', os.path.join(tmp_dir, 'Menger_sponge_sample.png'), 100, 1)
-            main.convert_file('data/Eiffel_tower_sample.STL', os.path.join(tmp_dir, 'Eiffel_tower_sample.png'), 100, 1)
+            convert_file('data/Cube_3d_printing_sample.stl', os.path.join(tmp_dir, 'Cube_3d_printing_sample.png'), 100, 1)
+            convert_file('data/Menger_sponge_sample.stl', os.path.join(tmp_dir, 'Menger_sponge_sample.png'), 100, 1)
+            convert_file('data/Eiffel_tower_sample.STL', os.path.join(tmp_dir, 'Eiffel_tower_sample.png'), 100, 1)
             # https://reprap.org/forum/read.php?88,6830
-            main.convert_file('data/HalfDonut.stl', os.path.join(tmp_dir, 'HalfDonut.png'), 100, 1)
-            main.convert_file('data/Star.stl', os.path.join(tmp_dir, 'Star.png'), 100, 1)
-            main.convert_file('data/Moon.stl', os.path.join(tmp_dir, 'Moon.png'), 100, 1)
+            convert_file('data/HalfDonut.stl', os.path.join(tmp_dir, 'HalfDonut.png'), 100, 1)
+            convert_file('data/Star.stl', os.path.join(tmp_dir, 'Star.png'), 100, 1)
+            convert_file('data/Moon.stl', os.path.join(tmp_dir, 'Moon.png'), 100, 1)
 
     def test_export_xyz(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # https://commons.wikimedia.org/wiki/File:Stanford_Bunny.stl
-            main.convert_file('data/Stanford_Bunny.stl', os.path.join(tmp_dir, 'stanford_bunny.xyz'), 100, 1)
+            convert_file('data/Stanford_Bunny.stl', os.path.join(tmp_dir, 'stanford_bunny.xyz'), 100, 1)
 
     def test_export_svx(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # https://commons.wikimedia.org/wiki/File:Stanford_Bunny.stl
-            main.convert_file('data/Stanford_Bunny.stl', os.path.join(tmp_dir, 'stanford_bunny.svx'), 100, 1)
+            convert_file('data/Stanford_Bunny.stl', os.path.join(tmp_dir, 'stanford_bunny.svx'), 100, 1)
 
     def test_issue_files(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Provided by @silverscorpio in issue #16
-            main.convert_file('data/test1.stl', os.path.join(tmp_dir, 'test1.png'), 100, 1)
+            convert_file('data/test1.stl', os.path.join(tmp_dir, 'test1.png'), 100, 1)
             # Provided by @silverscorpio in PR #18
-            main.convert_file('data/test2.stl', os.path.join(tmp_dir, 'test2.png'), 100, 1)
+            convert_file('data/test2.stl', os.path.join(tmp_dir, 'test2.png'), 100, 1)
             # Provided by @cogitas3d in issue #13
-            main.convert_file('data/Model.stl', os.path.join(tmp_dir, 'Model.png'), 512, 1)
-            main.convert_file('data/Model.stl', os.path.join(tmp_dir, 'Model.png'), 1024, 1)
+            convert_file('data/Model.stl', os.path.join(tmp_dir, 'Model.png'), 512, 1)
+            convert_file('data/Model.stl', os.path.join(tmp_dir, 'Model.png'), 1024, 1)
 
     def test_resolution(self):
         for i in range(1, 100):
             print('resolution:', i)
             with tempfile.TemporaryDirectory() as tmp_dir:
-                main.convert_file('data/Pyramid.stl', os.path.join(tmp_dir, 'Pyramid.xyz'), i, 1)
+                convert_file('data/Pyramid.stl', os.path.join(tmp_dir, 'Pyramid.xyz'), i, 1)
 
     def test_sparse_resolution(self):
         i = 1
         while i < 100:
             with tempfile.TemporaryDirectory() as tmp_dir:
-                main.convert_file('data/Cube_3d_printing_sample.stl',
-                                  os.path.join(tmp_dir, 'Cube_3d_printing_sample.xyz'), [i, i+1, i+2], 1)
+                convert_file('data/Cube_3d_printing_sample.stl',
+                             os.path.join(tmp_dir, 'Cube_3d_printing_sample.xyz'), [i, i+1, i+2], 1)
                 i += 1
-                main.convert_file('data/Menger_sponge_sample.stl',
-                                  os.path.join(tmp_dir, 'Menger_sponge_sample.svx'), [i, i+1, i+2], 1)
+                convert_file('data/Menger_sponge_sample.stl',
+                             os.path.join(tmp_dir, 'Menger_sponge_sample.svx'), [i, i+1, i+2], 1)
                 i += 1
-                main.convert_file('data/Eiffel_tower_sample.STL',
-                                  os.path.join(tmp_dir, 'Eiffel_tower_sample.svx'), [i, i+1, i+2], 1)
+                convert_file('data/Eiffel_tower_sample.STL',
+                             os.path.join(tmp_dir, 'Eiffel_tower_sample.svx'), [i, i+1, i+2], 1)
                 i += 1
 
     def test_convert_mesh(self):
@@ -70,7 +70,7 @@ class TestMain(unittest.TestCase):
             [[18, -13, 0], [18, 11, 0], [42, 11, 0]],
             [[30, 0, 25], [18, 11, 0], [18, -13, 0]],
         ])
-        voxels, _scale, _shift = main.convert_mesh(mesh, resolution=10)
+        voxels, _scale, _shift = convert_mesh(mesh, resolution=10)
         voxels = voxels.astype(int)
         expected = np.array([
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/test/test_perimeter.py
+++ b/test/test_perimeter.py
@@ -1,7 +1,6 @@
 import numpy as np
 import unittest
 
-from .context import stltovoxel  # noqa: F401
 from stltovoxel import perimeter
 
 

--- a/test/test_slice.py
+++ b/test/test_slice.py
@@ -1,7 +1,6 @@
 import numpy as np
 import unittest
 
-from .context import stltovoxel  # noqa: F401
 from stltovoxel import slice
 
 


### PR DESCRIPTION
In this pull request, the `main.py` has been split to allow to use package directly with command `python -m stltovoxel`.

The content of `main.py` is stored in `convert.py`, and the entrypoint is stored `__main__.py`

With such modification, the warning that appeared at launch just disappeared!