### PR TITLE
Add workflow to publish package to pypi

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,8 +66,7 @@ jobs:
         --wheel
         --outdir dist/
         .
-    - name: Publish distribution 📦 to Test PyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,3 +40,34 @@ jobs:
     - name: Test with nose
       run: |
         nosetests test/
+
+  build-n-publish:
+
+    # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Turn STL files into voxels, images, and videos
 ## How to run
 ### Run in command line
 ```
-pip install git+https://github.com/cpederkoff/stl-to-voxel.git
+pip install stl-to-voxel
 stltovoxel input.stl output.png
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name='stl-to-voxel',
-    version='0.9.1',
+    version='0.9.2',
     description='Turn STL files into voxels, images, and videos',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR would enable a workflow to publish this package to PyPI on a push.
I've already published the current version for use as a dependency for [my project](https://github.com/marmig0404/stl-in-mc).

@cpederkoff I can transfer ownership of this package on PyPI to you, make an account [here](https://pypi.org/).
After, set a Github secret **"PYPI_API_TOKEN"** as your PyPI API token to enable the workflow.