### PR TITLE
Optimize export functions using NumPy vectorization

### DIFF
--- a/stltovoxel/convert.py
+++ b/stltovoxel/convert.py
@@ -109,24 +109,21 @@ def export_pngs(voxels, output_file_path, colors):
 
 
 def export_xyz(voxels, output_file_path, scale, shift):
-    voxels = voxels.astype(bool)
-    output = open(output_file_path, "w")
-    for z in range(voxels.shape[0]):
-        for y in range(voxels.shape[1]):
-            for x in range(voxels.shape[2]):
-                if voxels[z][y][x]:
-                    point = (np.array([x, y, z]) / scale) + shift
-                    output.write("%s %s %s\n" % tuple(point))
-    output.close()
+    points = _get_transformed_points(voxels, scale, shift)
+
+    with open(output_file_path, "w") as output:
+        for point in points:
+            output.write("%s %s %s\n" % tuple(point))
 
 
 def export_npy(voxels, output_file_path, scale, shift):
+    points = _get_transformed_points(voxels, scale, shift)
+    np.save(output_file_path, points)
+
+
+def _get_transformed_points(voxels, scale, shift):
     voxels = voxels.astype(bool)
-    out = []
-    for z in range(voxels.shape[0]):
-        for y in range(voxels.shape[1]):
-            for x in range(voxels.shape[2]):
-                if voxels[z][y][x]:
-                    point = (np.array([x, y, z]) / scale) + shift
-                    out.append(point)
-    np.save(output_file_path, out)
+    true_coords = np.where(voxels)
+    coords = np.vstack(true_coords).T
+    coords = coords[:, [2, 1, 0]]
+    return (coords / scale) + shift


### PR DESCRIPTION
- Replace nested for-loops with vectorized NumPy operations in export_xyz and export_npy
- Use np.where() to find all True voxels in a single operation
- Process coordinates in bulk rather than individually
- Extract common transformation logic into _get_transformed_points helper function
- Apply scale and shift transformations to all points at once
- Improve file handling with context manager in export_xyz
- Eliminate list appending in export_npy for direct array creation

Based on my benchmarking, this vectorized approach is faster than the original implementation, with the greatest improvements seen at lower voxel densities.

![benchmark_comparison](https://github.com/user-attachments/assets/da8e3748-1c1c-4ef3-b262-507cae997d85)

Script for the benchmark:

```py
import os
import time
import numpy as np
import pandas as pd
import matplotlib.pyplot as plt

os.makedirs("data", exist_ok=True)
os.makedirs("docs/images", exist_ok=True)


# Implementation 1: Original nested for-loops
def original_export_xyz(array, scale, shift):
    result = []
    for z in range(array.shape[0]):
        for y in range(array.shape[1]):
            for x in range(array.shape[2]):
                if array[z, y, x]:
                    coords = np.array([x, y, z]) * scale + shift
                    result.append(coords.tolist())
    return result


# Implementation 2: NumPy optimized with vectorized operations
def numpy_optimized_export_xyz(array, scale, shift):
    indices = np.where(array)
    coords = np.stack([indices[2], indices[1], indices[0]], axis=1)
    transformed_coords = coords * scale + shift
    return transformed_coords.tolist()


def create_test_array(shape, density, seed=42):
    rng = np.random.RandomState(seed)
    return rng.random(shape) < density


def benchmark_function(func, array, scale, shift, runs=5):
    times = []
    results = None

    for _ in range(runs):
        start_time = time.time()
        result = func(array, scale, shift)
        end_time = time.time()
        times.append(end_time - start_time)

        if results is None:
            results = result

    return {
        "mean_time": np.mean(times),
        "min_time": np.min(times),
        "max_time": np.max(times),
        "results": results,
    }


def run_simple_benchmark():
    """Run a simple benchmark comparing original vs optimized implementations."""
    # Fixed parameters
    shape = (100, 100, 100)
    densities = [0.1, 0.5, 0.9]
    scale = 10.0
    shift = np.array([1.0, 2.0, 3.0])
    runs = 5

    # Functions to benchmark
    functions = {
        "Original": original_export_xyz,
        "Optimized": numpy_optimized_export_xyz,
    }

    # Results storage
    results = []

    # Print header
    print("=" * 80)
    print("SIMPLE BENCHMARK: ORIGINAL VS OPTIMIZED")
    print("=" * 80)
    print(f"Array size: {shape}")
    print(f"Densities: {densities}")
    print(f"Runs per configuration: {runs}")
    print("=" * 80)

    # Run benchmarks for each density
    for density in densities:
        print(f"\nRunning benchmark with density {density:.1f}...")

        # Create test array
        array = create_test_array(shape, density)
        true_count = np.sum(array)
        print(
            f"  Array has {true_count} True values ({true_count / np.prod(shape):.1%} of total)"
        )

        # Benchmark each function
        for name, func in functions.items():
            print(f"  Benchmarking {name}...")
            benchmark_result = benchmark_function(func, array, scale, shift, runs)

            # Store results
            results.append(
                {
                    "Implementation": name,
                    "Density": density,
                    "Time (s)": benchmark_result["mean_time"],
                    "Min Time (s)": benchmark_result["min_time"],
                    "Max Time (s)": benchmark_result["max_time"],
                    "True Values": true_count,
                }
            )

            print(f"    Mean time: {benchmark_result['mean_time']:.4f}s")

    # Convert results to DataFrame
    df = pd.DataFrame(results)

    # Print summary table
    print("\n" + "=" * 80)
    print("BENCHMARK SUMMARY")
    print("=" * 80)
    summary_table = df.pivot_table(
        index="Density", columns="Implementation", values="Time (s)"
    )
    summary_table["Speedup"] = summary_table["Original"] / summary_table["Optimized"]
    print(summary_table)
    print("\n" + "=" * 80)

    # Save results to CSV
    csv_path = "data/benchmark_simple.csv"
    df.to_csv(csv_path, index=False)
    print(f"Results saved to {csv_path}")

    # Create visualization
    create_visualization(df)

    return df


def create_visualization(df):
    """Create a visualization of the benchmark results."""
    plt.figure(figsize=(10, 6))

    # Create grouped bar chart
    bar_width = 0.35
    densities = sorted(df["Density"].unique())
    x = np.arange(len(densities))

    # Get data for each implementation
    original_data = (
        df[df["Implementation"] == "Original"].sort_values("Density")["Time (s)"].values
    )
    optimized_data = (
        df[df["Implementation"] == "Optimized"]
        .sort_values("Density")["Time (s)"]
        .values
    )

    # Plot bars
    plt.bar(
        x - bar_width / 2, original_data, bar_width, label="Original", color="steelblue"
    )
    plt.bar(
        x + bar_width / 2,
        optimized_data,
        bar_width,
        label="Optimized",
        color="forestgreen",
    )

    # Add speedup text above bars
    for i, density in enumerate(densities):
        speedup = original_data[i] / optimized_data[i]
        plt.text(
            i,
            max(original_data[i], optimized_data[i]) + 0.05,
            f"{speedup:.1f}x faster",
            ha="center",
            va="bottom",
            fontweight="bold",
        )

    # Add labels and title
    plt.xlabel("Density of True Values")
    plt.ylabel("Execution Time (seconds)")
    plt.title("Performance Comparison: Original vs Optimized Implementation")
    plt.xticks(x, [f"{d:.1f}" for d in densities])
    plt.legend()
    plt.grid(axis="y", linestyle="--", alpha=0.7)

    # Save figure
    plt.tight_layout()
    image_path = "docs/images/benchmark_comparison.png"
    plt.savefig(image_path, dpi=300)
    print(f"Visualization saved to {image_path}")


def main():
    """Run the simple benchmark."""
    run_simple_benchmark()
    print("\nBenchmark complete!")


if __name__ == "__main__":
    main()
```

In a single run of the whole test suite on my machine, it ran in ~2% less time:

**Before**

```sh
: poetry run pytest
............................     [100%]
28 passed in 160.95s (0:02:40)
```

**After**

```sh
: poetry run pytest
............................     [100%]
28 passed in 157.94s (0:02:37)
```
